### PR TITLE
Add offline fallback and precache

### DIFF
--- a/offline.html
+++ b/offline.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CloudControl - Offline</title>
+    <link rel="icon" href="./assets/icons/favicon.ico" type="image/x-icon">
+    <link rel="stylesheet" href="./styles/main.css">
+    <style>
+        .offline-container {
+            min-height: 100vh;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            text-align: center;
+            padding: 2rem;
+        }
+        .offline-container img {
+            height: 80px;
+            margin-bottom: 1.5rem;
+        }
+        .offline-container h1 {
+            margin-bottom: 1rem;
+        }
+    </style>
+</head>
+<body>
+    <div class="offline-container">
+        <img src="./assets/images/logo.png" alt="CloudControl Logo">
+        <h1>Você está offline</h1>
+        <p>Verifique sua conexão com a internet e tente novamente.</p>
+        <a class="btn-secondary" href="/">Voltar</a>
+    </div>
+</body>
+</html>

--- a/sw.js
+++ b/sw.js
@@ -17,6 +17,7 @@ const PRECACHE_ASSETS = [
     '/utils/formatters.js',
     '/utils/validators.js',
     '/utils/helpers.js',
+    '/offline.html',
     '/services/firebase/config.js',
     '/services/firebase/auth-service.js',
     '/assets/images/logo.png',


### PR DESCRIPTION
## Summary
- provide `offline.html` for offline users
- add the offline page to the service worker precache list

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6849f990e3748329a77e02e347140784