### PR TITLE
Refine Firebase Storage rules

### DIFF
--- a/storage.rules
+++ b/storage.rules
@@ -1,10 +1,7 @@
 rules_version = '2';
 service firebase.storage {
   match /b/{bucket}/o {
-    match /{allPaths=**} {
-      allow read: if request.auth != null;
-      allow write: if request.auth != null;
-    }
+    // Remove permissão ampla; acessos são definidos por caminho específico
     
     match /users/{userId}/{allPaths=**} {
       allow read: if request.auth != null;
@@ -24,9 +21,10 @@ service firebase.storage {
                     request.resource.metadata.role == 'admin';
     }
     
-    match /receipts/{allPaths=**} {
-      allow read: if request.auth != null;
-      allow write: if request.auth != null;
+    match /receipts/{userId}/{allPaths=**} {
+      allow read, write: if request.auth != null &&
+                         (request.auth.uid == userId ||
+                          request.auth.token.role == 'admin');
     }
     
     match /backups/{allPaths=**} {


### PR DESCRIPTION
## Summary
- tighten Firebase Storage security rules

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6849f996c5a88329ac55e061ff08248a