### PR TITLE
Add Jest tests for validators

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  presets: [['@babel/preset-env', { targets: { node: 'current' } }]],
+};

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "npx serve -s .",
     "build": "node build.js",
     "deploy": "npm run build && firebase deploy",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "keywords": [
     "gestão",
@@ -27,7 +27,10 @@
     "imagemin-mozjpeg": "^10.0.0",
     "imagemin-pngquant": "^9.0.2",
     "serve": "^14.2.0",
-    "terser": "^5.16.8"
+    "terser": "^5.16.8",
+    "jest": "^29.6.1",
+    "babel-jest": "^29.6.1",
+    "@babel/preset-env": "^7.22.5"
   },
   "dependencies": {
     "firebase": "^9.22.0"
@@ -50,4 +53,3 @@
   },
   "homepage": "https://github.com/EliteIE/CloudControl#readme"
 }
-

--- a/tests/validators.test.js
+++ b/tests/validators.test.js
@@ -1,0 +1,21 @@
+import { isValidEmail, isValidCPF } from '../utils/validators.js';
+
+describe('isValidEmail', () => {
+  it('returns true for a valid email', () => {
+    expect(isValidEmail('test@example.com')).toBe(true);
+  });
+
+  it('returns false for an invalid email', () => {
+    expect(isValidEmail('invalid-email')).toBe(false);
+  });
+});
+
+describe('isValidCPF', () => {
+  it('returns true for a valid CPF', () => {
+    expect(isValidCPF('52998224725')).toBe(true);
+  });
+
+  it('returns false for an invalid CPF', () => {
+    expect(isValidCPF('12345678900')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add a Jest configuration
- test `isValidEmail` and `isValidCPF`
- configure `npm test` to run Jest

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849f6702c7483299771fd03b608165f