### PR TITLE
Fix accept header check in Service Worker

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -132,9 +132,10 @@ self.addEventListener('fetch', event => {
                     })
                     .catch(error => {
                         console.error('❌ Service Worker: Erro de fetch:', error);
-                        
+
                         // Para páginas HTML, retornar página offline
-                        if (event.request.headers.get('accept').includes('text/html')) {
+                        const acceptHeader = event.request.headers.get('accept');
+                        if (acceptHeader && acceptHeader.includes('text/html')) {
                             return caches.match('/offline.html');
                         }
                         


### PR DESCRIPTION
## Summary
- handle missing `Accept` header in service worker fetch handler

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6849f672d5448329abd5e39548c204c1